### PR TITLE
Remove stray repository string from footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -977,4 +977,3 @@
     <script src="./packages/js/main.js"></script>
   </body>
 </html>
-ghosh-ayush/ghosh-ayush.github.io


### PR DESCRIPTION
## Summary
- remove extraneous `ghosh-ayush/ghosh-ayush.github.io` string after closing HTML tag in index.html

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68963e8b7ea4832cbf04c5c6bd5c48dc